### PR TITLE
Fix README example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,5 +28,5 @@ demo: [fangpeishi.com](http://fangpeishi.com)
 ```
 
 ANOTHER_READ_MORE_LINK = "Read more"
-ANOTHER_READ_MORE_LINK_FORMAT = "<a class="another-read-more-link" href="{url}" >{text}</a>"
+ANOTHER_READ_MORE_LINK_FORMAT = '<a class="another-read-more-link" href="{url}">{text}</a>'
 ```


### PR DESCRIPTION
The problem is that double quotes are not escaped. Using a single quote solves the problem.